### PR TITLE
Use HTTPS tunnel (stunnel4) to bypass deep packet inspection.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get -q update        \
 	iptables             \
 	iptables-persistent  \
 	openvpn              \
+	stunnel4             \
 	uuid                 \
  && apt-get clean
 

--- a/overlay/etc/default/openvpn
+++ b/overlay/etc/default/openvpn
@@ -88,3 +88,6 @@ chmod 600 /etc/openvpn/key.pem
     openssl req -new -key /etc/openvpn/key.pem -out /etc/openvpn/csr.pem -subj /CN=OpenVPN/
 [ -f /etc/openvpn/cert.pem ] || \
     openssl x509 -req -in /etc/openvpn/csr.pem -out /etc/openvpn/cert.pem -signkey /etc/openvpn/key.pem -days 24855
+[ -f /etc/stunnel/stunnel.pem ] || \
+    cat /etc/openvpn/key.pem /etc/openvpn/cert.pem >> /etc/stunnel/stunnel.pem && \
+    sed -i s/ENABLED=0/ENABLED=1/g /etc/default/stunnel4

--- a/overlay/etc/openvpn/tcp443.conf
+++ b/overlay/etc/openvpn/tcp443.conf
@@ -15,3 +15,4 @@ port 443
 dev tun443
 status openvpn-status-443.log
 log-append /var/log/openvpn-tcp443.log
+port-share 127.0.0.1 442

--- a/overlay/etc/stunnel/stunnel.conf
+++ b/overlay/etc/stunnel/stunnel.conf
@@ -1,0 +1,6 @@
+cert = /etc/stunnel/stunnel.pem
+
+[openvpn-localhost]
+accept = 127.0.0.1:442
+connect = 127.0.0.1:443
+


### PR DESCRIPTION
Fix #21
