### PR TITLE
Adapt for EasyRSA 3 and Ubuntu 20.04

### DIFF
--- a/latest/overlay/etc/openvpn/scw-vars.sh
+++ b/latest/overlay/etc/openvpn/scw-vars.sh
@@ -15,10 +15,18 @@ export ipv4_prefix='100.64'
 export ipv4_dns_servers="$(host_ipv4_dns)"
 
 export easyrsa="/etc/openvpn/easy-rsa"
-export easyrsa_keys="${easyrsa}/keys"
-export openvpn_tls_cipher=''
-export openvpn_cipher='AES-256-CBC'
-export openvpn_tls_version_min='1.2'
+export easyrsa_keys="${easyrsa}/pki"
+
+export openvpn_tls_version_min='1.3'
+
+# TLS 1.3 encryption settings
+export openvpn_ecdh_curve="secp384r1"
+export openvpn_tls_ciphersuites='TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256'
+
+# TLS 1.2 encryption settings
+export openvpn_tls_cipher="TLS-ECDHE-ECDSA-WITH-CHACHA20-POLY1305-SHA256:TLS-ECDHE-RSA-WITH-CHACHA20-POLY1305-SHA256:TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256:TLS-ECDHE-RSA-WITH-AES-128-GCM-SHA256"
+
+export openvpn_cipher='AES-128-GCM'
 export openvpn_auth='SHA256'
 
 export ipv4_net="${ipv4_prefix}.0.0/16"

--- a/latest/overlay/etc/openvpn/vars
+++ b/latest/overlay/etc/openvpn/vars
@@ -1,0 +1,209 @@
+# Easy-RSA 3 parameter settings
+
+# NOTE: If you installed Easy-RSA from your distro's package manager, don't edit
+# this file in place -- instead, you should copy the entire easy-rsa directory
+# to another location so future upgrades don't wipe out your changes.
+
+# HOW TO USE THIS FILE
+#
+# vars.example contains built-in examples to Easy-RSA settings. You MUST name
+# this file 'vars' if you want it to be used as a configuration file. If you do
+# not, it WILL NOT be automatically read when you call easyrsa commands.
+#
+# It is not necessary to use this config file unless you wish to change
+# operational defaults. These defaults should be fine for many uses without the
+# need to copy and edit the 'vars' file.
+#
+# All of the editable settings are shown commented and start with the command
+# 'set_var' -- this means any set_var command that is uncommented has been
+# modified by the user. If you're happy with a default, there is no need to
+# define the value to its default.
+
+# NOTES FOR WINDOWS USERS
+#
+# Paths for Windows  *MUST* use forward slashes, or optionally double-esscaped
+# backslashes (single forward slashes are recommended.) This means your path to
+# the openssl binary might look like this:
+# "C:/Program Files/OpenSSL-Win32/bin/openssl.exe"
+
+# A little housekeeping: DON'T EDIT THIS SECTION
+# 
+# Easy-RSA 3.x doesn't source into the environment directly.
+# Complain if a user tries to do this:
+if [ -z "$EASYRSA_CALLER" ]; then
+	echo "You appear to be sourcing an Easy-RSA 'vars' file." >&2
+	echo "This is no longer necessary and is disallowed. See the section called" >&2
+	echo "'How to use this file' near the top comments for more details." >&2
+	return 1
+fi
+
+# DO YOUR EDITS BELOW THIS POINT
+
+# This variable is used as the base location of configuration files needed by
+# easyrsa.  More specific variables for specific files (e.g., EASYRSA_SSL_CONF)
+# may override this default.
+#
+# The default value of this variable is the location of the easyrsa script
+# itself, which is also where the configuration files are located in the
+# easy-rsa tree.
+
+#set_var EASYRSA	"${0%/*}"
+
+# If your OpenSSL command is not in the system PATH, you will need to define the
+# path to it here. Normally this means a full path to the executable, otherwise
+# you could have left it undefined here and the shown default would be used.
+#
+# Windows users, remember to use paths with forward-slashes (or escaped
+# back-slashes.) Windows users should declare the full path to the openssl
+# binary here if it is not in their system PATH.
+
+#set_var EASYRSA_OPENSSL	"openssl"
+#
+# This sample is in Windows syntax -- edit it for your path if not using PATH:
+#set_var EASYRSA_OPENSSL	"C:/Program Files/OpenSSL-Win32/bin/openssl.exe"
+
+# Edit this variable to point to your soon-to-be-created key directory.  By
+# default, this will be "$PWD/pki" (i.e. the "pki" subdirectory of the
+# directory you are currently in).
+#
+# WARNING: init-pki will do a rm -rf on this directory so make sure you define
+# it correctly! (Interactive mode will prompt before acting.)
+
+#set_var EASYRSA_PKI		"$PWD/pki"
+
+# Define X509 DN mode.
+# This is used to adjust what elements are included in the Subject field as the DN
+# (this is the "Distinguished Name.")
+# Note that in cn_only mode the Organizational fields further below aren't used.
+#
+# Choices are:
+#   cn_only  - use just a CN value
+#   org      - use the "traditional" Country/Province/City/Org/OU/email/CN format
+
+#set_var EASYRSA_DN	"cn_only"
+
+# Organizational fields (used with 'org' mode and ignored in 'cn_only' mode.)
+# These are the default values for fields which will be placed in the
+# certificate.  Don't leave any of these fields blank, although interactively
+# you may omit any specific field by typing the "." symbol (not valid for
+# email.)
+
+set_var EASYRSA_REQ_COUNTRY	"FR"
+set_var EASYRSA_REQ_PROVINCE	"Idf"
+set_var EASYRSA_REQ_CITY	"Paris"
+set_var EASYRSA_REQ_ORG		"ACME"
+set_var EASYRSA_REQ_EMAIL	"me@example.net"
+set_var EASYRSA_REQ_OU		"My Organizational Unit"
+
+# Choose a size in bits for your keypairs. The recommended value is 2048.  Using
+# 2048-bit keys is considered more than sufficient for many years into the
+# future. Larger keysizes will slow down TLS negotiation and make key/DH param
+# generation take much longer. Values up to 4096 should be accepted by most
+# software. Only used when the crypto alg is rsa (see below.)
+
+#set_var EASYRSA_KEY_SIZE	2048
+
+# The default crypto mode is rsa; ec can enable elliptic curve support.
+# Note that not all software supports ECC, so use care when enabling it.
+# Choices for crypto alg are: (each in lower-case)
+#  * rsa
+#  * ec
+
+set_var EASYRSA_ALGO		ec
+
+# Define the named curve, used in ec mode only:
+
+set_var EASYRSA_CURVE		secp384r1
+
+# In how many days should the root CA key expire?
+
+set_var EASYRSA_CA_EXPIRE	3650
+
+# In how many days should certificates expire?
+
+set_var EASYRSA_CERT_EXPIRE	2160
+
+# How many days until the next CRL publish date?  Note that the CRL can still be
+# parsed after this timeframe passes. It is only used for an expected next
+# publication date.
+
+# How many days before its expiration date a certificate is allowed to be
+# renewed?
+#set_var EASYRSA_CERT_RENEW	30
+
+#set_var EASYRSA_CRL_DAYS	180
+
+# Support deprecated "Netscape" extensions? (choices "yes" or "no".) The default
+# is "no" to discourage use of deprecated extensions. If you require this
+# feature to use with --ns-cert-type, set this to "yes" here. This support
+# should be replaced with the more modern --remote-cert-tls feature.  If you do
+# not use --ns-cert-type in your configs, it is safe (and recommended) to leave
+# this defined to "no".  When set to "yes", server-signed certs get the
+# nsCertType=server attribute, and also get any NS_COMMENT defined below in the
+# nsComment field.
+
+#set_var EASYRSA_NS_SUPPORT	"no"
+
+# When NS_SUPPORT is set to "yes", this field is added as the nsComment field.
+# Set this blank to omit it. With NS_SUPPORT set to "no" this field is ignored.
+
+#set_var EASYRSA_NS_COMMENT	"Easy-RSA Generated Certificate"
+
+# A temp file used to stage cert extensions during signing. The default should
+# be fine for most users; however, some users might want an alternative under a
+# RAM-based FS, such as /dev/shm or /tmp on some systems.
+
+#set_var EASYRSA_TEMP_FILE	"$EASYRSA_PKI/extensions.temp"
+
+# !!
+# NOTE: ADVANCED OPTIONS BELOW THIS POINT
+# PLAY WITH THEM AT YOUR OWN RISK
+# !!
+
+# Broken shell command aliases: If you have a largely broken shell that is
+# missing any of these POSIX-required commands used by Easy-RSA, you will need
+# to define an alias to the proper path for the command.  The symptom will be
+# some form of a 'command not found' error from your shell. This means your
+# shell is BROKEN, but you can hack around it here if you really need. These
+# shown values are not defaults: it is up to you to know what you're doing if
+# you touch these.
+#
+#alias awk="/alt/bin/awk"
+#alias cat="/alt/bin/cat"
+
+# X509 extensions directory:
+# If you want to customize the X509 extensions used, set the directory to look
+# for extensions here. Each cert type you sign must have a matching filename,
+# and an optional file named 'COMMON' is included first when present. Note that
+# when undefined here, default behaviour is to look in $EASYRSA_PKI first, then
+# fallback to $EASYRSA for the 'x509-types' dir.  You may override this
+# detection with an explicit dir here.
+#
+#set_var EASYRSA_EXT_DIR	"$EASYRSA/x509-types"
+
+# OpenSSL config file:
+# If you need to use a specific openssl config file, you can reference it here.
+# Normally this file is auto-detected from a file named openssl-easyrsa.cnf from the
+# EASYRSA_PKI or EASYRSA dir (in that order.) NOTE that this file is Easy-RSA
+# specific and you cannot just use a standard config file, so this is an
+# advanced feature.
+
+#set_var EASYRSA_SSL_CONF	"$EASYRSA/openssl-easyrsa.cnf"
+
+# Default CN:
+# This is best left alone. Interactively you will set this manually, and BATCH
+# callers are expected to set this themselves.
+
+#set_var EASYRSA_REQ_CN		"ChangeMe"
+
+# Cryptographic digest to use.
+# Do not change this default unless you understand the security implications.
+# Valid choices include: md5, sha1, sha256, sha224, sha384, sha512
+
+#set_var EASYRSA_DIGEST		"sha256"
+
+# Batch mode. Leave this disabled unless you intend to call Easy-RSA explicitly
+# in batch mode without any user input, confirmation on dangerous operations,
+# or most output. Setting this to any non-blank string enables batch mode.
+
+set_var EASYRSA_BATCH		""

--- a/latest/overlay/usr/local/bin/scw-ovpn-create-client
+++ b/latest/overlay/usr/local/bin/scw-ovpn-create-client
@@ -21,6 +21,5 @@ for client_name in "$@"; do
 	fail "There already is a certificate with name '${client_name}'" 2
     fi
 
-    . ./vars
-    ./pkitool "${client_name}"
+    ./easyrsa build-client-full "${client_name}" nopass
 done

--- a/latest/overlay/usr/local/bin/scw-ovpn-gen-server
+++ b/latest/overlay/usr/local/bin/scw-ovpn-gen-server
@@ -36,10 +36,10 @@ verb 3
 
 # CERTS
 duplicate-cn
-key  ${easyrsa_keys}/${server_name}.key
-cert ${easyrsa_keys}/${server_name}.crt
+key  ${easyrsa_keys}/private/${server_name}.key
+cert ${easyrsa_keys}/issued/${server_name}.crt
 ca   ${easyrsa_keys}/ca.crt
-dh   ${easyrsa_keys}/dh2048.pem
+dh none
 
 # hardening
 remote-cert-tls client
@@ -47,9 +47,24 @@ tls-auth ${easyrsa_keys}/ta.key 0
 crl-verify ${easyrsa_keys}/crl.pem
 
 $(optional tls-version-min "${openvpn_tls_version_min}")
-$(optional tls-cipher "${openvpn_tls_cipher}")
-$(optional cipher "${openvpn_cipher}")
+# TLS 1.3 encryption settings
+$(optional tls-ciphersuites "${openvpn_tls_ciphersuites}")
+# use the NSA's recommended curve
+$(optional ecdh-curve "${openvpn_ecdh_curve}")
+
+# TLS 1.2 encryption settings
+#$(optional tls-cipher "${openvpn_tls_cipher}")
+
+
+#this tells OpenVPN which side of the TLS handshake it is
+#tls-client on the client
+tls-server
+
 $(optional auth "${openvpn_auth}")
+# data channel cipher
+$(optional cipher "${openvpn_cipher}")
+# don't negotiate ciphers, we know what we want
+ncp-disable
 
 reneg-sec 60
 EOF

--- a/latest/overlay/usr/local/bin/scw-ovpn-init-server
+++ b/latest/overlay/usr/local/bin/scw-ovpn-init-server
@@ -20,25 +20,17 @@ logdo () {
     "$program" "$@"
 }
 
-
 mkdir -p "${easyrsa}"
+cp vars "${easyrsa}"
 cd "${easyrsa}"
-cp /usr/share/easy-rsa/* .
+cp -a /usr/share/easy-rsa/* .
 
-source ./vars
+./easyrsa init-pki
+./easyrsa build-ca nopass
+./easyrsa gen-crl
+./easyrsa build-server-full myvpn nopass
 
-logdo ./clean-all
-logdo ./pkitool --initca
-logdo ./pkitool --server myvpn
-logdo ./build-dh
-
-logdo openvpn --genkey --secret "${KEY_DIR}"/ta.key
-
-# easy-rsa does not generate the initial revocation list
-export KEY_CN='sample'
-export KEY_ALTNAMES='sample'
-logdo openssl ca -gencrl -out "${KEY_DIR}"/crl.pem -config "${KEY_CONFIG}"
-
+logdo openvpn --genkey --secret "${easyrsa}/pki/ta.key"
 
 touch "${easyrsa}"/done
 

--- a/latest/overlay/usr/local/bin/scw-ovpn-revoke-client
+++ b/latest/overlay/usr/local/bin/scw-ovpn-revoke-client
@@ -13,7 +13,6 @@ client_name="$(expect "$1" 'missing client name')"
 
 cd "${easyrsa}"
 
-. ./vars
-./revoke-full "${client_name}"
+./easyrsa revoke "${easyrsa_keys}/issued/${client_name}.crt"
 
 systemctl reload openvpn

--- a/latest/overlay/usr/local/bin/scw-ovpn-show-client
+++ b/latest/overlay/usr/local/bin/scw-ovpn-show-client
@@ -20,14 +20,13 @@ get () {
 
 set_common() {
     ca_crt="$(get ca.crt)"
-    dh2048="$(get dh2048.pem)"
     tls_auth="$(get ta.key)"
 }
 
 
 set_client_specific () {
-    key="$(get ${client_name}.key)"
-    cert="$(get ${client_name}.crt)"
+    key="$(get private/${client_name}.key)"
+    cert="$(get issued/${client_name}.crt)"
 }
 
 
@@ -58,15 +57,16 @@ ${cert}
 <ca>
 ${ca_crt}
 </ca>
-<dh>
-${dh2048}
-</dh>
 
 # hardening
 remote-cert-tls server
 
 $(optional tls-version-min "${openvpn_tls_version_min}")
-$(optional tls-cipher "${openvpn_tls_cipher}")
+# TLS 1.3 encryption settings
+$(optional tls-ciphersuites "${openvpn_tls_ciphersuites}")
+# use the NSA's recommended curve
+$(optional ecdh-curve "${openvpn_ecdh_curve}")
+
 $(optional cipher "${openvpn_cipher}")
 $(optional auth "${openvpn_auth}")
 


### PR DESCRIPTION
- Use Easyrsa 3
- Adapt for Ubuntu 20.04
- Remove DH
- Force TLS to 1.3 (latest version)
- Use only strong ciphers
- Use ECC certificates/keys